### PR TITLE
add new letters on user creation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 2017
+    }
+}

--- a/server/api/letters.js
+++ b/server/api/letters.js
@@ -1,17 +1,46 @@
 const router = require('express').Router()
 const { Letter, LetterCategory } = require('../db/models')
+const { getRandomLetterId } = require('../utils/letterIdFrequency')
 module.exports = router
 
+LAT_DISPLACEMENT = 0.004
+LONG_DISPLACEMENT = 0.004
+NORMALIZATION = 0.002
+
+router.post('/', async (req, res, next) => {
+  let { latitude, longitude } = req.body
+  let letter, letterCategoryId
+  try {
+    for (let i = 0; i < 40; i++) {
+      letterCategoryId = getRandomLetterId()
+      letter = await LetterCategory.findById(letterCategoryId)
+      await Letter.create({
+        letterCategoryId,
+        latitude: Math.random() * LAT_DISPLACEMENT - NORMALIZATION + Number(latitude),
+        longitude: Math.random() * LONG_DISPLACEMENT - NORMALIZATION + Number(longitude),
+        displacementDistance: Math.random() * letter.points,
+        displacementBearing: Math.random() * 360
+      })
+    }
+    res.sendStatus(200)
+  } catch (error) {
+    console.error(error)
+  }
+})
 
 router.get('/', (req, res, next) => {
   if (req.query.hidden) {
     Letter.findAll({ include: [{ model: LetterCategory }] })
-      .then(allLetters => allLetters.filter(letter => letter.hidden.toString() === req.query.hidden))
+      .then(allLetters =>
+        allLetters.filter(
+          letter => letter.hidden.toString() === req.query.hidden
+        )
+      )
       .then(selectedLetters => res.json(selectedLetters))
       .catch(next)
   } else {
     Letter.findAll({ include: [{ model: LetterCategory }] })
-      .then((userLetters) => res.json(userLetters))
+      .then(userLetters => res.json(userLetters))
       .catch(next)
   }
 })

--- a/server/db/models/user.js
+++ b/server/db/models/user.js
@@ -3,6 +3,7 @@ const Sequelize = require('sequelize')
 const db = require('../db')
 const Letter = require('./letter')
 const LetterCategory = require('./letterCategory')
+const { getRandomLetterId } = require('../../utils/letterIdFrequency')
 
 const User = db.define('user', {
   userName: {
@@ -77,11 +78,6 @@ const setSaltAndPassword = user => {
 }
 
 const addLetters = async user => {
-  const letterIdFrequency = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4, 4,
-    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 7, 7, 7, 8, 8, 9, 9, 9, 9, 9, 9,
-    9, 9, 9, 10, 11, 12, 12, 12, 12, 13, 13, 14, 14, 14, 14, 14, 14, 15, 15, 15,
-    15, 15, 15, 15, 15, 16, 16, 17, 18, 18, 18, 18, 18, 18, 19, 19, 19, 19, 20,
-    20, 20, 20, 20, 20, 21, 21, 21, 21, 22, 22, 23, 23, 24, 25, 25, 26]
 
   let letterCategoryId,
       letter,
@@ -90,10 +86,7 @@ const addLetters = async user => {
 
   try {
     for (let i = 0; i < 7; i++) {
-      letterCategoryId =
-        letterIdFrequency[
-          Math.floor(Math.random() * letterIdFrequency.length) + 1
-        ]
+      letterCategoryId = getRandomLetterId()
       letter = await LetterCategory.findById(letterCategoryId)
       displacementDistance = Math.random() * letter.points
       displacementBearing = Math.random() * 360

--- a/server/utils/letterIdFrequency.js
+++ b/server/utils/letterIdFrequency.js
@@ -1,0 +1,13 @@
+const letterIdFrequency = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4, 4,
+  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 7, 7, 7, 8, 8, 9, 9, 9, 9, 9, 9,
+  9, 9, 9, 10, 11, 12, 12, 12, 12, 13, 13, 14, 14, 14, 14, 14, 14, 15, 15, 15,
+  15, 15, 15, 15, 15, 16, 16, 17, 18, 18, 18, 18, 18, 18, 19, 19, 19, 19, 20,
+  20, 20, 20, 20, 20, 21, 21, 21, 21, 22, 22, 23, 23, 24, 25, 25, 26]
+
+const getRandomLetterId = () =>
+  letterIdFrequency[Math.floor(Math.random() * letterIdFrequency.length)]
+
+module.exports = {
+  letterIdFrequency,
+  getRandomLetterId
+}


### PR DESCRIPTION
Added a POST request handler to `api/letters` that adds 40 letters near a new user's location. First attempted to make this a hook on the `User` model, but to do so required the `userLocation`, which would have meant needing to store the user's initial location in the model (bad). Also thought to refactor the existing POST route to `api/users` to create new letters as well, but in the end chose to keep the concerns separate. 

+ adding the .eslintrc got rid of an annoying false error flag when using async/await
+ abstracted the letter frequency array into Utils and added a function to grab a category Id at random so it could be used from multiple places